### PR TITLE
update: update gitignore to ignore object files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 sfo
 .vscode
+*.o


### PR DESCRIPTION
### What
This change updates the gitignore to also ignore `.o` files.

### Why
To avoid committing object files as per best practices, especially since our docs suggest the command `git add .` in the *Example Workflow* section.

### How
Added `*.o` entry to the gitignore.

### Screenshots
N/A

### Testing
1. `make`
2. `git status`
3. verified `.o` files were ignored

### Related Issues
N/A
