### PR TITLE
refactor: refactor cli command handling

### DIFF
--- a/include/cli.h
+++ b/include/cli.h
@@ -6,6 +6,11 @@
 #include <stdint.h>
 #include <string.h>
 
+#define  CMD_BACKUP "backup"
+#define  CMD_EXIT "exit"
+#define  CMD_ORGANIZE "organize"
+#define  CMD_STATUS "status"
+
 #define  USER_COMMAND_READ_ERROR  -1
 #define  USER_COMMAND_READ_SUCCESS 0
 
@@ -16,6 +21,26 @@ struct program_state {
     bool    is_running;                 //stores the current state of the program
     char    input_buff[USR_BUFF_CAP];   //holds the user input
 };
+
+// This struct groups a user command with its corresponding handler function
+typedef struct {
+    const char *command;
+    command_handler_t handler;
+} command_dispatch_table_t;
+
+/*
+    The function signature for a command handler function.
+
+    The handler must take a single argument of type `program_state *`,
+        and it must return `void`.
+*/
+typedef void (*command_handler_t)(struct program_state *);
+
+// Command handler prototypes
+void handle_organize(struct program_state *program_struct);
+void handle_backup(struct program_state *program_struct);
+void handle_status(struct program_state *program_struct);
+void handle_exit(struct program_state *program_struct);
 
 /*
     This function is responsible to get the user input and handle it

--- a/src/cli.c
+++ b/src/cli.c
@@ -3,38 +3,56 @@
 // Static function declare
 static int8_t format_null(struct program_state *program_struct);
 
+void handle_organize(struct program_state *program_struct) {
+    // TODO: Implement organize command
+}
+
+void handle_backup(struct program_state *program_struct) {
+    // TODO: Implement backup command
+}
+
+void handle_status(struct program_state *program_struct) {
+    // TODO: Implement status command
+}
+
+void handle_exit(struct program_state *program_struct) {
+    printf("Bye :)\n");
+    program_struct->is_running = false;
+}
+
+/*
+    A function dispatch table for CLI user commands.
+    It maps a user command to the function that handles that command.
+*/
+const command_dispatch_table_t command_dispatch_table[] = {
+    {CMD_ORGANIZE, handle_organize},
+    {CMD_BACKUP, handle_backup},
+    {CMD_STATUS, handle_status},
+    {CMD_EXIT, handle_exit},
+    {NULL, NULL} // Sentinel value to mark the end of the dispatch table
+};
+
 /*
     Function to handle user input
 */
 int read_input(struct program_state *program_struct) {
-    if (NULL == program_struct )
+    if (NULL == program_struct)
         return USER_COMMAND_READ_ERROR;
 
     fgets(program_struct->input_buff, USR_BUFF_CAP, stdin); // Get the input
     if (format_null(program_struct) != 0)
         return USER_COMMAND_READ_ERROR;
 
-
-    /*
-        The code below is dedicated to handle the commands
-    */
-    if (strcmp(program_struct->input_buff, "organize") == 0) {
-        // TODO: handle organize command
-
-    } else if (strcmp(program_struct->input_buff, "backup") == 0) {
-        // TODO: handle backup command
-
-    } else if (strcmp(program_struct->input_buff, "status") == 0) {
-        // TODO: handle status command
-
-    } else if (strcmp(program_struct->input_buff, "exit") == 0) {
-        printf("Bye :)\n");
-        program_struct->is_running = false;
+    // Get the corresponding handler for the user command, and execute it 
+    for (const command_dispatch_table_t *cmd = command_dispatch_table; cmd->command != NULL; ++cmd) {
+        if (strcmp(program_struct->input_buff, cmd->command) == 0) {
+            cmd->handler(program_struct);
+            return USER_COMMAND_READ_SUCCESS;
+        }
     }
 
-    return USER_COMMAND_READ_SUCESS;
+    return USER_COMMAND_READ_ERROR; // Command not found
 }
-
 
 /*
     A function to dedicate to format the input to change from a \n at the end to \0


### PR DESCRIPTION
### What
Refactored the CLI command handling to be more modular. 

### Why
This should make it easier to extend and maintain CLI command functionality, and significantly condenses the `read_input` function by avoiding repeated code.

### How
Introduced a function dispatch table that maps each command to a handler function that will perform the command. The handler functions are still marked as TODO, this was only a refactoring.

### Screenshots
N/A

### Testing
`read_input` isn't actually used anywhere yet, so I settled on making sure the project still compiled successfully ;) 

### Related Issues
N/A