### PR TITLE
Improved build process with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,21 +8,44 @@ project(SmartFileOrganizer)
 find_package(SndFile)
 find_package(LibArchive REQUIRED)
 
-add_executable(sfo 
-    src/main.c
-    src/file_type_detection/file_type_detector.c
-    src/file_type_detection/sound_files/get_sound_file_info.c
-    src/file_type_detection/archive_files/get_archive_file_info.c
-    src/organize.c
-    src/utils.c
-    src/backup.c
-    src/cli.c)
+file(GLOB_RECURSE SOURCE_DIRS LIST_DIRECTORIES true "${CMAKE_SOURCE_DIR}/src/*")
+file(GLOB_RECURSE INCLUDE_DIRS LIST_DIRECTORIES true "${CMAKE_SOURCE_DIR}/include/*")
 
+set(INCLUDES "")
+set(SOURCES "")
+
+foreach(ITEM ${SOURCE_DIRS})
+    if(NOT IS_DIRECTORY ${ITEM})
+        list(APPEND SOURCES ${ITEM})
+    endif()
+endforeach()
+
+foreach(ITEM ${INCLUDE_DIRS})
+    if(IS_DIRECTORY ${ITEM})
+        list(APPEND INCLUDES ${ITEM})
+    endif()
+endforeach()
+
+list(APPEND INCLUDES "${CMAKE_SOURCE_DIR}/include/")
+
+message(STATUS "Sources found: ${SOURCES}")
+message(STATUS "Include directories found: ${INCLUDES}")
+
+#Main target
+
+add_executable(sfo ${SOURCES})
 target_link_libraries(sfo PRIVATE SndFile::sndfile LibArchive::LibArchive magic)
 
-
+#Test sounds target
 add_executable(test_sounds
     tests/tests_get_sound_file_info.c
     src/file_type_detection/sound_files/get_sound_file_info.c)
+target_link_libraries(test_sounds PRIVATE cunit SndFile::sndfile)
 
-target_link_libraries(test_sounds PRIVATE cunit SndFile::sndfile
+#Test images target
+add_executable(test_images
+    tests/tests_get_image_files.c
+    src/file_type_detection/file_type_detector.c
+    src/file_type_detection/sound_files/get_sound_file_info.c
+    src/file_type_detection/image_files/get_image_files.c)
+target_link_libraries(test_images PRIVATE cunit magic SndFile::sndfile)

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,7 @@
 
 #include "../include/file_type_detector.h"
 #include "../include/sound_files/get_sound_file_info.h"
+#include "../include/image_files/get_image_files.h"
 #include "../include/organize.h"
 #include "../include/cli.h"
 #include "../include/utils.h"
@@ -15,6 +16,8 @@ int main(int argc, char *argv[])
 
   if (argc > 1)
   {
+
+    get_image_file_info("../tests/images/c_low_level.png");
 
     char *home = getenv("HOME");
     getcwd(program_path, sizeof(program_path));

--- a/src/organize.c
+++ b/src/organize.c
@@ -1,8 +1,6 @@
 #include "../include/organize.h"
 #define LINK_MAX_LEN 256
 
-const char *image_types[] = {"PNG", "JPEG", "JPG", "GIF", "BMP", "TIFF", "WEBP", "X-ICON"};
-
 char *user_home     = NULL;
 char *sfo_home      = NULL;
 char link_dst[LINK_MAX_LEN];


### PR DESCRIPTION
There is no need to manually adding source files to add_exectuable command for sfo main target. Also there is a list of sources and includes when the cmake build process is initiated.